### PR TITLE
Add libturbojpeg0-dev to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Build and install the KVM software in the SSH session:
 
 ```shell
 sudo apt update
-sudo apt install -y git janus janus-dev cmake g++ libglib2.0-dev
+sudo apt install -y git janus janus-dev cmake g++ libglib2.0-dev libturbojpeg0-dev
 sudo systemctl disable janus
 
 cd ~


### PR DESCRIPTION
kvm's build depends on libturbojpeg0-dev, so adding it to the README install instructions.

Fixes #2